### PR TITLE
fixed bugs for latest versions of react

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 venv
+env/
 node_modules
 static/bundle.js
 

--- a/js/Hello.js
+++ b/js/Hello.js
@@ -1,10 +1,16 @@
 import React from 'react';
 
-var Hello = React.createClass({
-  render() {
-    return <h1>Hello, world</h1>;
-  }
-});
+class Hello extends React.Component{
+    constructor(props){
+        super(props);
+        this.state = {}
+    }
+
+    render(){
+        return (
+            <h1>Hello, world</h1>
+        )
+    }
+}
 
 export default Hello;
-

--- a/js/app.js
+++ b/js/app.js
@@ -1,6 +1,6 @@
-import Hello from './Hello';
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { render } from 'react-dom';
 
-ReactDOM.render(<Hello/>, document.getElementById('reactEntry'));
+import Hello from './Hello';
 
+render(<Hello/>,document.getElementById('react'));

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "webpack": "^1.12.12"
   },
   "dependencies": {
-    "react": "^0.14.7",
-    "react-dom": "^0.14.7"
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0"
   }
 }


### PR DESCRIPTION
In the latest versions of react (^16.2.0). React.createClass is deprecated. The pull request fixes this by using the recommended extends React.Component method